### PR TITLE
Hotfix event timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2-beta
-      - uses: actions/setup-node@v1.1.0
+      - uses: actions/setup-node@v1.4.04
         with:
           version: 10.x
       - name: build and unit test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2-beta
-      - uses: actions/setup-node@v1.4.04
+      - uses: actions/setup-node@v1.4.4
         with:
           version: 10.x
       - name: build and unit test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+-   Fix EventMetadata default timestamp
+
 ## 2.0.2
 
 -   Renamed some events for consistency, pulled 2.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ironcorelabs/tenant-security-nodejs",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "NodeJS client library for the IronCore Labs Tenant Security Proxy.",
     "homepage": "https://ironcorelabs.com/docs",
     "main": "src/index.js",

--- a/src/logdriver/EventMetadata.ts
+++ b/src/logdriver/EventMetadata.ts
@@ -62,11 +62,10 @@ export class EventMetadata {
         if (!requestingUserOrServiceId) {
             throw new Error("Must provide a valid requestingUserOrServiceId for all CMK operations.");
         }
-        const now = new Date();
         this.tenantId = tenantId;
         this.requestingUserOrServiceId = requestingUserOrServiceId;
         this.dataLabel = dataLabel;
-        this.timestampMillis = timestampMillis || now.getTime() + now.getTimezoneOffset() * 60 * 1000;
+        this.timestampMillis = timestampMillis || Date.now();
         this.sourceIp = sourceIp;
         this.objectId = objectId;
         this.requestId = requestId;

--- a/src/logdriver/tests/EventMetadata.test.ts
+++ b/src/logdriver/tests/EventMetadata.test.ts
@@ -51,7 +51,8 @@ describe("UNIT EventMetadata", () => {
 
     test("defaults timestamp to something close to now", () => {
         const withPartialFields = new EventMetadata("tenantId", "user", "label");
+        const now = Date.now();
 
-        expect(withPartialFields.toJsonStructure().timestampMillis).toBeGreaterThan(Date.now() - 1000);
+        expect(withPartialFields.toJsonStructure().timestampMillis).toBeWithin(now - 1000, now + 1000);
     });
 });


### PR DESCRIPTION
Timestamp calculation was wrong and was causing an issue with Stackdriver, who was quietly rejecting future stamped messages.

Fixed and added a test to catch this in the future (confirmed the test doesn't pass with the broken branch).