### PR TITLE
Add function to re-key an encrypted document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 33-rekey
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
-    needs: get_refs
+    # needs: get_refs TODO: uncomment
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.2
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: IronCoreLabs/tenant-security-proxy
-          ref: ${{ needs.get_refs.outputs.tenant-security-proxy }}
+          ref: master # TODO change back to: ${{ needs.get_refs.outputs.tenant-security-proxy }}
           path: tenant-security-proxy
           token: ${{ secrets.TSP_PAT }}
       # Work around https://github.com/actions/cache/issues/133#issuecomment-599102035

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches:
       - master
-      - 33-rekey
   pull_request:
 
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
-    # needs: get_refs TODO: uncomment
+    needs: get_refs
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.2
@@ -24,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: IronCoreLabs/tenant-security-proxy
-          ref: master # TODO change back to: ${{ needs.get_refs.outputs.tenant-security-proxy }}
+          ref: ${{ needs.get_refs.outputs.tenant-security-proxy }}
           path: tenant-security-proxy
           token: ${{ secrets.TSP_PAT }}
       # Work around https://github.com/actions/cache/issues/133#issuecomment-599102035

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0 (Unreleased)
+
+-   Added `TenantSecurityClient.rekeyDocument` method and support `RekeyResponse` type
+
 ## 2.0.3
 
 -   Fix EventMetadata default timestamp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@
 
 -   Added `TenantSecurityClient.logSecurityEvent` method and supporting `SecurityEvent` and `EventMetadata` types
 -   Standardized `EventMetadata` and `DocumentMetadata` to similar interfaces with the TSP
--   Introduced an exception hierachy based on TSP error codes. `TenantSecurityKMSException` renamed to `TenantSecurityException` and
+-   Introduced an exception hierarchy based on TSP error codes. `TenantSecurityKMSException` renamed to `TenantSecurityException` and
     `KmsException`, `SecurityEventException`, and `TspServiceException` are subclasses.
 -   Renamed `TenantSecurityKMSClient` to `TenantSecurityClient`
 
 ### Compatibility
 
-This version of the Tenant Security Java Client will only work with version `3.0.0+` of the Tenant Security Proxy container.
+This version of the Tenant Security NodeJS Client will only work with version `3.0.0+` of the Tenant Security Proxy container.
 
 ## 1.0.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ See our [TSP documentation](https://ironcorelabs.com/docs/saas-shield/tenant-sec
 
 ## Tests
 
-This client has both a set of unit tests as well as several integration test suites. Because of the complexity of the various services requried to run non-unit test suites, these tests require additional setup, which is explained below.
+This client has both a set of unit tests as well as several integration test suites. Because of the complexity of the various services required to run non-unit test suites, these tests require additional setup, which is explained below.
 
 ### Unit Tests
 
@@ -18,7 +18,7 @@ yarn test
 
 #### Local Development Integration Tests
 
-These tests are meant for local devlopers to be able to do a full end-to-end test from the client all the way through to the Config Broker. This test will perform multiple round-trip encryption and decryption tests and verify that the data is successfully decrypted to its original value. This test assumes that you've done the work of setting up the Tenant Security Proxy from above as well as setting up the associated Config Broker vendor account with a tenant and a KMS config. Open the [`LocalRoundTrip.test.ts`](src/tests/LocalRoundTrip.test.ts) file and set the values for your `LOCAL_TENANT_ID` and `LOCAL_API_KEY` within the test class. Once
+These tests are meant for local developers to be able to do a full end-to-end test from the client all the way through to the Config Broker. This test will perform multiple round-trip encryption and decryption tests and verify that the data is successfully decrypted to its original value. This test assumes that you've done the work of setting up the Tenant Security Proxy from above as well as setting up the associated Config Broker vendor account with a tenant and a KMS config. Open the [`LocalRoundTrip.test.ts`](src/tests/LocalRoundTrip.test.ts) file and set the values for your `LOCAL_TENANT_ID` and `LOCAL_API_KEY` within the test class. Once
 set you can run them via:
 
 ```
@@ -32,7 +32,7 @@ We've created a number of accounts within a Config Broker dev enviroment that ha
 ## Publishing
 
 To release a new version of the package to NPM, first update the `version` field in `package.json`.
-We use *semver* semantics, so carefully consider whether the change breaks any interfaces to consumers of the package.
+We use _semver_ semantics, so carefully consider whether the change breaks any interfaces to consumers of the package.
 
 Once the version is updated and committed, simply run `./build.js --publish` to build and test the package, then push the package to the NPM repository.
 If your account is configured to require a One-Time Passcode (OTP), add `--otp` to the command line.
@@ -45,6 +45,7 @@ If your tests don't build again the default branch of that repo, you can change 
 comment should contain the string `CI_branches` and a JSON object like
 `{"tenant-security-proxy": "some_branch"}`. You can include formatting, prose, or a haiku,
 but no `{` or `}` characters. Example:
+
 ```
 CI_branches: `{"tenant-security-proxy": "some_branch"}`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ yarn local
 
 #### Complete Integration Tests
 
-We've created a number of accounts within a Config Broker dev enviroment that have tenants set up for all the different KMS types that we support. This allows us to run a more complete suite of integration tests that exercise more parts of both the client as well as the Tenant Security Proxy. These tests are not runnable by the public. You can view the results of these test runs in [CI](https://github.com/IronCoreLabs/tenant-security-client-nodejs/actions).
+We've created a number of accounts within a Config Broker dev environment that have tenants set up for all the different KMS types that we support. This allows us to run a more complete suite of integration tests that exercise more parts of both the client as well as the Tenant Security Proxy. These tests are not runnable by the public. You can view the results of these test runs in [CI](https://github.com/IronCoreLabs/tenant-security-client-nodejs/actions).
 
 ## Publishing
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,14 @@
         "trailingComma": "es5",
         "bracketSpacing": false,
         "jsxBracketSameLine": true,
-        "arrowParens": "always"
+        "arrowParens": "always",
+        "overrides": [
+            {
+                "files": "*.yml",
+                "options": {
+                    "tabWidth": 2
+                }
+            }
+        ]
     }
 }

--- a/src/kms/KmsApi.ts
+++ b/src/kms/KmsApi.ts
@@ -18,6 +18,8 @@ interface WrapKeyResponse {
     edek: Base64String;
 }
 
+export type RekeyResponse = WrapKeyResponse;
+
 export type BatchWrapKeyResponse = BatchResponse<WrapKeyResponse>;
 
 interface UnwrapKeyResponse {
@@ -30,6 +32,7 @@ const WRAP_ENDPOINT = "document/wrap";
 const UNWRAP_ENDPOINT = "document/unwrap";
 const BATCH_WRAP_ENDPOINT = "document/batch-wrap";
 const BATCH_UNWRAP_ENDPOINT = "document/batch-unwrap";
+const REKEY_ENDPOINT = "document/rekey";
 
 /**
  * Generate and wrap a new key via the tenant's KMS.
@@ -91,5 +94,27 @@ export const batchUnwrapKey = (
         JSON.stringify({
             ...metadata.toJsonStructure(),
             edeks,
+        })
+    );
+
+/**
+ * Take an EDEK and send it to the tenant's KMS via the TSP to be unwrapped,
+ * then send the key to the new tenant's KMS via the TSP to be wrapped.
+ */
+export const rekeyKey = (
+    tspDomain: string,
+    apiKey: string,
+    edek: Base64String,
+    newTenantId: string,
+    metadata: DocumentMetadata
+): Future<TenantSecurityException, RekeyResponse> =>
+    makeJsonRequest(
+        tspDomain,
+        apiKey,
+        REKEY_ENDPOINT,
+        JSON.stringify({
+            ...metadata.toJsonStructure(),
+            encryptedDocumentKey: edek,
+            newTenantId,
         })
     );

--- a/src/kms/TenantSecurityClient.ts
+++ b/src/kms/TenantSecurityClient.ts
@@ -183,6 +183,15 @@ export class TenantSecurityClient {
     };
 
     /**
+     * Re-key a document to the provided tenant ID. Takes the document and EDEK returned on encrypt and unwraps the EDEK via
+     * the original tenant's KMS. Then re-wraps that DEK with the new tenant's KMS and returns an unchanged EncryptedDocument with a new EDEK.
+     */
+    rekeyDocument = (encryptedDoc: EncryptedDocumentWithEdek, newTenantId: string, metadata: DocumentMetadata): Promise<EncryptedDocumentWithEdek> =>
+        KmsApi.rekeyKey(this.tspDomain, this.apiKey, encryptedDoc.edek, newTenantId, metadata)
+            .map((rekeyResponse) => <EncryptedDocumentWithEdek>{encryptedDocument: encryptedDoc.encryptedDocument, edek: rekeyResponse.edek})
+            .toPromise();
+
+    /**
      * Send the provided security event to the TSP to be logged and analyzed. Returns void if
      * the security event was successfully received. Note that logging a security event is an asynchronous operation
      * at the TSP, so successful receipt of a security event does not mean that the event is deliverable or has

--- a/src/kms/TenantSecurityClient.ts
+++ b/src/kms/TenantSecurityClient.ts
@@ -188,7 +188,7 @@ export class TenantSecurityClient {
      */
     rekeyDocument = (encryptedDoc: EncryptedDocumentWithEdek, newTenantId: string, metadata: DocumentMetadata): Promise<EncryptedDocumentWithEdek> =>
         KmsApi.rekeyKey(this.tspDomain, this.apiKey, encryptedDoc.edek, newTenantId, metadata)
-            .map((rekeyResponse) => <EncryptedDocumentWithEdek>{encryptedDocument: encryptedDoc.encryptedDocument, edek: rekeyResponse.edek})
+            .map((rekeyResponse) => ({encryptedDocument: encryptedDoc.encryptedDocument, edek: rekeyResponse.edek}))
             .toPromise();
 
     /**

--- a/src/kms/TenantSecurityClient.ts
+++ b/src/kms/TenantSecurityClient.ts
@@ -183,8 +183,9 @@ export class TenantSecurityClient {
     };
 
     /**
-     * Re-key a document to the provided tenant ID. Takes the document and EDEK returned on encrypt and unwraps the EDEK via
+     * Re-key a document to the a new tenant ID. Takes the document and EDEK returned on encrypt and unwraps the EDEK via
      * the original tenant's KMS. Then re-wraps that DEK with the new tenant's KMS and returns an unchanged EncryptedDocument with a new EDEK.
+     * The old tenant and new tenant can be the same in order to re-key the document to the tenant's latest primary config.
      */
     rekeyDocument = (encryptedDoc: EncryptedDocumentWithEdek, newTenantId: string, metadata: DocumentMetadata): Promise<EncryptedDocumentWithEdek> =>
         KmsApi.rekeyKey(this.tspDomain, this.apiKey, encryptedDoc.edek, newTenantId, metadata)

--- a/src/kms/tests/DocumentMetadata.test.ts
+++ b/src/kms/tests/DocumentMetadata.test.ts
@@ -1,6 +1,6 @@
 import {DocumentMetadata} from "../../index";
 
-describe("UNIT DocumentMetdata", () => {
+describe("UNIT DocumentMetadata", () => {
     test("construction fails when tenantId is missing.", () => {
         expect(() => new DocumentMetadata(undefined as any, undefined as any)).toThrow();
         expect(() => new DocumentMetadata("tenantId", undefined as any)).toThrow();

--- a/src/tests/DevIntegration.test.ts
+++ b/src/tests/DevIntegration.test.ts
@@ -185,6 +185,32 @@ describe("INTEGRATION dev environment tests", () => {
         });
     });
 
+    describe("roundtrip re-key encrypt and decrypt", () => {
+        it("roundtrips a collection of fields from AWS to self", async () => {
+            await TestUtils.runSingleDocumentRekeyRoundTripForTenants(client, AWS_TENANT_ID, AWS_TENANT_ID);
+        });
+
+        it("roundtrips a collection of fields from AWS to GCP", async () => {
+            await TestUtils.runSingleDocumentRekeyRoundTripForTenants(client, AWS_TENANT_ID, GCP_TENANT_ID);
+        });
+
+        it("roundtrips a collection of fields from GCP to self", async () => {
+            await TestUtils.runSingleDocumentRekeyRoundTripForTenants(client, GCP_TENANT_ID, GCP_TENANT_ID);
+        });
+
+        it("roundtrips a collection of fields from GCP to Azure", async () => {
+            await TestUtils.runSingleDocumentRekeyRoundTripForTenants(client, GCP_TENANT_ID, AZURE_TENANT_ID);
+        });
+
+        it("roundtrips a collection of fields from Azure to self", async () => {
+            await TestUtils.runSingleDocumentRekeyRoundTripForTenants(client, AZURE_TENANT_ID, AZURE_TENANT_ID);
+        });
+
+        it("roundtrips a collection of fields from Azure to AWS", async () => {
+            await TestUtils.runSingleDocumentRekeyRoundTripForTenants(client, AZURE_TENANT_ID, AWS_TENANT_ID);
+        });
+    });
+
     describe("test tenant with multiple configs", () => {
         it("fails to encrypt new data with no primary config", async () => {
             const data = TestUtils.getDataToEncrypt();

--- a/src/tests/LocalRoundTrip.test.ts
+++ b/src/tests/LocalRoundTrip.test.ts
@@ -34,7 +34,7 @@ describe("LOCAL Integration Tests", () => {
     });
 
     describe("log security event", () => {
-        conditionalTest("with a bad tenant sucessfully passes to the TSP.", async () => {
+        conditionalTest("with a bad tenant successfully passes to the TSP.", async () => {
             const tenant_id = "bad-tenant-id";
             const metadata = new EventMetadata(tenant_id, "integrationTest", "sample", undefined, undefined, undefined, "app-request-id");
 


### PR DESCRIPTION
Adds `TenantSecurityClient.rekeyDocument` function. Adds an alias `RekeyResponse` which is just a `WrapResponse`.
Added a function to `TestUtils` to re-key from one tenant to another. 
Added calls to the test util function in `DevIntegration.test.ts`.
I didn't add a test to the local round trip because it's on the dev to add tenant IDs to that file (or else we skip the tests) and it seemed over-engineered to conditionally skip even more tests in that file if multiple tenant IDs aren't filled in. But I could if we wanted to.

I also added an override to `package.json` to allow prettier to use 2 space indentation for `.yml` files instead of the 4 we use for the rest of the repo. Let me know if you don't like this solution.