### PR TITLE
Use the org-level PAT instead of the repo local one.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           repository: IronCoreLabs/tenant-security-proxy
           ref: ${{ needs.get_refs.outputs.tenant-security-proxy }}
           path: tenant-security-proxy
-          token: ${{ secrets.TSP_PAT }}
+          token: ${{ secrets.WORKFLOW_PAT }}
       - name: cache cargo
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
The `TSP_PAT` that's in use now is listed in leeroy's account as `tenant-security-client-nodejs CI to clone TSP`. It's using an [old format](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/) and should be deleted.

Once we merge this PR, we can:
- [ ] Remove `TSP_PAT` from this repo's secrets.
- [ ] Delete the PAT from leeroy's account.