### PR TITLE
Update CHANGELOG with deprecated TSP interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,4 +44,4 @@ Initial open source release
 
 ### Compatibility
 
-This version of the Tenant Security NodeJS Client will only work with version `>= 2.0.0 < 4.0.0` of the Tenant Security Proxy container.
+This version of the Tenant Security NodeJS Client will only work with version `>= 2.0.0 < 4.0.0` of the Tenant Security Proxy container due to a deprecated interface. `TSP v3` supports both the old and new interfaces and can be used to migrate TSCs if necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,8 @@ This version of the Tenant Security NodeJS Client will only work with version `3
 ## 1.0.0
 
 Initial open source release
+
+
+### Compatibility
+
+This version of the Tenant Security NodeJS Client will only work with version `>= 2.0.0 < 4.0.0` of the Tenant Security Proxy container.


### PR DESCRIPTION
v1 of the TSC-nodejs used the older TSP metadata interface. `TSP v3` supports both metadata interfaces and can be used to migrate between TSC-nodejs versions if necessary.