### PR TITLE
Add a version header on calls to the TSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Added header to TSP and Logdriver calls with the current TSC version and language. These can be consumed in TSP metrics and are useful to track migrations or find out of date TSC callers.
+
 ## 4.0.0
 
 -   Encryption now throws a `TscException` when trying to encrypt a document that has already been IronCore encrypted.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Check in the `examples` subdirectory - there are subdirectories for some example
 
 The Tenant Security Client is licensed under the [GNU Affero General Public License](https://github.com/IronCoreLabs/ironoxide/blob/main/LICENSE). We also offer commercial licenses - [email](mailto:info@ironcorelabs.com) for more information.
 
-Copyright (c) 2021 IronCore Labs, Inc. All rights reserved.
+Copyright (c) 2023 IronCore Labs, Inc. All rights reserved.

--- a/package.json
+++ b/package.json
@@ -1,64 +1,64 @@
 {
-    "name": "@ironcorelabs/tenant-security-nodejs",
-    "version": "4.0.0",
-    "description": "NodeJS client library for the IronCore Labs Tenant Security Proxy.",
-    "homepage": "https://ironcorelabs.com/docs",
-    "main": "src/index.js",
-    "repository": "git@github.com:IronCoreLabs/tenant-security-client-nodejs.git",
-    "author": "IronCore Labs",
-    "license": "AGPL-3.0-only",
-    "types": "src/index.d.ts",
-    "engines": {
-        "node": ">=14.0.0"
-    },
-    "scripts": {
-        "build": "./build.js",
-        "test": "yarn run lint && yarn run unit",
-        "unit": "jest -t UNIT",
-        "integration": "jest -t \"INTEGRATION|UNIT\"",
-        "local": "jest -t LOCAL",
-        "lint": "eslint . --ext .ts",
-        "testsingle": "jest",
-        "protobuild": "pbjs -t static-module -w commonjs -o proto/ts/DocumentHeader.js proto/document_header.proto && pbts -o proto/ts/DocumentHeader.d.ts proto/ts/DocumentHeader.js"
-    },
-    "dependencies": {
-        "futurejs": "2.2.0",
-        "miscreant": "^0.3.2",
-        "node-fetch": "2.6.12",
-        "protobufjs": "^7.2.4"
-    },
-    "devDependencies": {
-        "@types/jest": "^25.2.3",
-        "@types/node": "^13.13.15",
-        "@types/node-fetch": "^2.5.7",
-        "@typescript-eslint/eslint-plugin": "^3.9.1",
-        "@typescript-eslint/parser": "^3.9.1",
-        "eslint": "^6.8.0",
-        "jest": "^26.4.1",
-        "jest-extended": "^0.11.5",
-        "prompt": "^1.0.0",
-        "protobufjs-cli": "^1.1.1",
-        "shelljs": "^0.8.4",
-        "ts-jest": "^26.2.0",
-        "ts-node": "^8.10.2",
-        "typescript": "^3.9.7",
-        "typestrict": "^1.0.2",
-        "uglify-js": "^3.7.7"
-    },
-    "prettier": {
-        "printWidth": 160,
-        "tabWidth": 4,
-        "trailingComma": "es5",
-        "bracketSpacing": false,
-        "jsxBracketSameLine": true,
-        "arrowParens": "always",
-        "overrides": [
-            {
-                "files": "*.yml",
-                "options": {
-                    "tabWidth": 2
-                }
-            }
-        ]
-    }
+  "name": "@ironcorelabs/tenant-security-nodejs",
+  "version": "4.0.1",
+  "description": "NodeJS client library for the IronCore Labs Tenant Security Proxy.",
+  "homepage": "https://ironcorelabs.com/docs",
+  "main": "src/index.js",
+  "repository": "git@github.com:IronCoreLabs/tenant-security-client-nodejs.git",
+  "author": "IronCore Labs",
+  "license": "AGPL-3.0-only",
+  "types": "src/index.d.ts",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "scripts": {
+    "build": "./build.js",
+    "test": "yarn run lint && yarn run unit",
+    "unit": "jest -t UNIT",
+    "integration": "jest -t \"INTEGRATION|UNIT\"",
+    "local": "jest -t LOCAL",
+    "lint": "eslint . --ext .ts",
+    "testsingle": "jest",
+    "protobuild": "pbjs -t static-module -w commonjs -o proto/ts/DocumentHeader.js proto/document_header.proto && pbts -o proto/ts/DocumentHeader.d.ts proto/ts/DocumentHeader.js"
+  },
+  "dependencies": {
+    "futurejs": "2.2.0",
+    "miscreant": "^0.3.2",
+    "node-fetch": "2.6.12",
+    "protobufjs": "^7.2.4"
+  },
+  "devDependencies": {
+    "@types/jest": "^25.2.3",
+    "@types/node": "^13.13.15",
+    "@types/node-fetch": "^2.5.7",
+    "@typescript-eslint/eslint-plugin": "^3.9.1",
+    "@typescript-eslint/parser": "^3.9.1",
+    "eslint": "^6.8.0",
+    "jest": "^26.4.1",
+    "jest-extended": "^0.11.5",
+    "prompt": "^1.0.0",
+    "protobufjs-cli": "^1.1.1",
+    "shelljs": "^0.8.4",
+    "ts-jest": "^26.2.0",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.9.7",
+    "typestrict": "^1.0.2",
+    "uglify-js": "^3.7.7"
+  },
+  "prettier": {
+    "printWidth": 160,
+    "tabWidth": 4,
+    "trailingComma": "es5",
+    "bracketSpacing": false,
+    "jsxBracketSameLine": true,
+    "arrowParens": "always",
+    "overrides": [
+      {
+        "files": "*.yml",
+        "options": {
+          "tabWidth": 2
+        }
+      }
+    ]
+  }
 }

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -44,7 +44,7 @@ export const makeJsonRequest = <T,>(tspDomain: string, apiKey: string, route: st
             headers: {
                 "Content-Type": "application/json",
                 Authorization: `cmk ${apiKey}`,
-                "x-icl-tsc-language": "nodejs",
+                "x-icl-tsc-language": "node",
                 "x-icl-tsc-version": `${version}`,
             },
             agent: agentSelector,

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -4,6 +4,7 @@ import {ApiErrorResponse} from "./kms/KmsApi";
 import {TenantSecurityErrorCode, TenantSecurityException} from "./TenantSecurityException";
 import {TenantSecurityExceptionUtils} from "./TenantSecurityExceptionUtils";
 import {TspServiceException} from "./TspServiceException";
+import {version} from "../package.json";
 import * as Crypto from "./kms/Crypto";
 import * as DetCrypto from "./kms/DeterministicCrypto";
 import * as http from "http";
@@ -35,7 +36,7 @@ const agentSelector = function (_parsedURL: any) {
  * Request the provided API endpoint with the provided POST data. All requests to the TSP today are in POST. On failure,
  * attempt to parse the failed JSON to extract an error code and message.
  */
-export const makeJsonRequest = <T>(tspDomain: string, apiKey: string, route: string, postData: string): Future<TenantSecurityException, T> =>
+export const makeJsonRequest = <T,>(tspDomain: string, apiKey: string, route: string, postData: string): Future<TenantSecurityException, T> =>
     Future.tryP(() =>
         fetch(`${tspDomain}/api/1/${route}`, {
             method: "POST",
@@ -43,6 +44,8 @@ export const makeJsonRequest = <T>(tspDomain: string, apiKey: string, route: str
             headers: {
                 "Content-Type": "application/json",
                 Authorization: `cmk ${apiKey}`,
+                "x-icl-tsc-language": "nodejs",
+                "x-icl-tsc-version": `${version}`,
             },
             agent: agentSelector,
         })
@@ -71,7 +74,7 @@ export const clearUndefinedProperties = (obj: {[key: string]: any}): {[key: stri
  * Take a batch result of encrypt/decrypt operations and convert it into the return structure from the SDK, calculating
  * some convenience fields on the response for successes and failures.
  */
-export const mapBatchOperationToResult = <T>(
+export const mapBatchOperationToResult = <T,>(
     successesAndFailures:
         | Record<string, Crypto.BatchEncryptResult>
         | Record<string, Crypto.BatchDecryptResult>


### PR DESCRIPTION
Which can be read from TSP metrics to try to identify outdated TSCs or track migrations. This adds the same header to Logdriver calls.