### PR TITLE
Add a deterministic recovery example

### DIFF
--- a/examples/disaster-recovery-example/README.md
+++ b/examples/disaster-recovery-example/README.md
@@ -85,6 +85,9 @@ all known keypaths / creds and map out the associations.
 
 
 ## Example Run Output
+
+Code for this process is in `src/index.ts`. It can be run with `yarn && yarn start` if you have IronCore GCP credentials. This same code could be modified or expanded on to work for your real data or recovery process, but it is not itself production quality code.
+
 ```console
 Unleased Encrypted Document: {
   "ssn": "\u0003IRON\u0000,\n\u001c������\"_���k,�\bj@���S\u001f�b3g�M\u001a\f\n\ntenant-gcp\u001a \u0002 Zک�\u0001��q*�\n\u000eq�/\u0004\u00122(��؋@ʹ�F\u0007K\u0005���",
@@ -151,6 +154,8 @@ Once you have the tenant's decrypted secret for this piece of data, you can crea
 Use the deterministic key to `AES-SIV` decrypt the deterministic data. There is no `AES-SIV` associated data on IronCore deterministic values.
 
 ### Example Run Output
+
+Code for this process is in `src/deterministic.ts`. It can be run with `yarn && yarn deterministic` if you have IronCore GCP credentials. This same code could be modified or expanded on to work for your real data or recovery process, but it is not itself production quality code.
 
 ```console
 Deterministic Encrypted Value:

--- a/examples/disaster-recovery-example/README.md
+++ b/examples/disaster-recovery-example/README.md
@@ -17,12 +17,14 @@ situations. 'Cause archeologists need love too!
 
 This example uses previously encrypted data from the other examples. When run, it deconstructs that data and reconstitutes the original decrypted data.
 
-The credentials to make running this yourself aren't provided, but you can see the code and example output for more information about what is happening.
+The credentials to run this yourself aren't provided, but you can see the code and example output for more information about what is happening.
+
+Information on IronCore document header shapes and protobuf formats can be found in the open-source [ironcore-documents](https://github.com/IronCoreLabs/ironcore-documents) repository. 
 
 ## Recovery Process
 
 ### Retrieving the Encrypted Bytes, GCM tag, and IV
-In the `EncryptedDocumentMap` (`Map<String, byte[]>`) returned by the TSC, the `byte[]`’s are of the structure:
+In the `EncryptedDocumentMap` (`Map<String, byte[]>`) returned by the TSC, the `byte[]`s in v3 documents are of the structure:
 
 ```
 VERSION_NUMBER (1 byte, fixed at 3)
@@ -35,6 +37,8 @@ GCM_TAG (16 bytes)
 ```
 
 `ENCRYPTED_DATA` are the bytes you’ll be decrypting, and the `DATA_IV` is needed to make the AES decryption call. You’ll also need the encryption key, obtained in the next step.
+
+See [ironcore-documents](https://github.com/IronCoreLabs/ironcore-documents) combined with the open-source code of the specific version of the TSC or IronCore Alloy that you're using to know what the document header structure of your data will be.
 
 ### Retrieving the Document Encryption Key
 The DEK (Document Encryption Key) you need to decrypt the `ENCRYPTED_DATA` is the decrypted value of the EDEK (Encrypted DEK) that was also returned by the TSC.
@@ -55,6 +59,9 @@ message EncryptedDeks {repeated EncryptedDek encryptedDeks = 1;}
 ```
 
 You need to decode the EDEK base64 as an `EncryptedDeks` message, then for disaster recovery you're safe to just use the first `EncryptedDek` in the resulting list of them. 
+
+See [ironcore-documents](https://github.com/IronCoreLabs/ironcore-documents) combined with the open-source code of the specific version of the TSC or IronCore Alloy that you're using for the most up to date information on what protobuf formats to expect.
+
 
 #### Un-leased
 If the `EncryptedDek.leasedKeyId` is `0` (zero) you can decrypt the DEK by calling unwrap on your (or the tenant’s) KMS, passing the `EncryptedDek.encryptedDekData` bytes, using the correct credentials and key path. The result will be the DEK which can then be used in the “Decrypting the Document” step. 
@@ -99,4 +106,82 @@ Leased Document: {
   "address": "2825-519 Stone Creek Rd, Bozeman, MT 59715",
   "name": "Jim Bridger"
 }
+```
+
+## Deterministic
+
+As mentioned in the [documentation on our website](https://ironcorelabs.com/docs/saas-shield/deterministic-encryption/#recovering-data) the recovery process for deterministically encrypted data requires a few extra steps. Deterministic data is encrypted with a key derived from a rotating tenant secret, which itself is wrapped by their KMS. To recover deterministic data then, we need to:
+
+1. Determine the ID of the secret used for our data.
+2. Retrieve that (previously backed up) encrypted secret.
+3. Decrypt the secret (using the method described in [Recovery Process](#recovery-process)).
+4. Use the secret to hash a string incorporating the derivation path and tenant ID.
+5. Use that string as a key to decrypt the data. 
+
+Let's go over those steps in more detail. A concrete commented Typescript example of this process can be found in `examples/disaster-recovery-example/src/deterministic.ts`.
+
+### Determine Secret ID
+
+We need to retrieve the ID of the secret that was used to encrypt our piece of data so the encrypted secret can be retrieved from backups.
+
+For deterministic data encrypted with the Tenant Security Clients (`tsc-java 6+`, `tsc-nodejs 3+`, not supported in `tsc-php` or `tsc-go`), the first 4 binary bytes contain the tenant secret ID and the next two bytes are padding.
+
+For deterministic data encrypted with IronCore Alloy the first 4 binary bytes contain the tenant secret ID. See [ironcore-alloy](https://github.com/IronCoreLabs/ironcore-alloy/blob/main/src/deterministic.rs) and [ironcore-documents](https://github.com/IronCoreLabs/ironcore-documents) source for the most up to date information.
+
+### Retrieve Secret
+
+Encrypted tenant secrets are available from the Configuration Broker and should be regularly backed up.
+
+In the UI a `.zip` of encrypted tenant secrets can be downloaded from the [Tenant Secrets page](https://config.staging.ironcorelabs.com/app/kms/secrets) of the Configuration Broker. Look for a clickable download icon near the page title.
+
+In the Vendor API Bridge a request to the [List Tenant Secrets](https://ironcore-labs.stoplight.io/docs/vendor-bridge/8ee4d2ba0dd9c-list-tenant-secrets) endpoint will return a `JSON` list of encrypted tenant secrets.
+
+These encrypted secrets need to be backed up in a way that they can be retrieved by secret ID reliably in a disaster scenario.
+
+### Decrypt Secret
+
+The secret is encrypted by the tenant's KMS, and the process described in [Recovery Process](#recovery-process) is used to decrypt it. Notably the secret will include a KMS config ID in its header (see [ironcore-documents](https://github.com/IronCoreLabs/ironcore-documents) for header formats), but without access to the Configuration Broker it won't be clear which of the tenants KMS key paths and credentials were referenced by that KMS config. In a true disaster scenario you'll need to work with the tenant to either provide them with these secrets and have them try decryption with all their KMS keys, or have them provide you or your recovery tool with credentials that can access all their possible KMS keys to try.
+
+### Create a Deterministic Key
+
+Once you have the tenant's decrypted secret for this piece of data you can create a deterministic key. Use the secret as a key to `HMAC-SHA512` sign over `"tenant_provided_id-derivation_path"`. The output of the hash is the deterministic key used to decrypt the actual data.
+
+### Decrypt the Data
+
+Use the deterministic key to `AES-SIV` decrypt the deterministic data.
+
+### Example Run Output
+
+```console
+Deterministic Encrypted Value:
+          AAAT9wAAeFKwSikcVVSXpGj8z2/7bYkDpEue9kUlUxOj
+Recovered Secret ID:
+          5111
+Retrieved Backup Secret: {
+	"tenantProvidedId": "tenant-gcp",
+	"numericId": 5111,
+	"id": "4a7f76dd-a0fb-4642-b15b-8423a983cc88",
+	"tenantSecretId": 5111,
+	"secretFingerprint": "tMoo5p0wpn3J2AS3iJptVWAS19B9zvj1nDGltf40wos=",
+	"secretPath": "secretPath",
+	"kmsConfigId": 510,
+	"migrationStatus": 1,
+	"encryptedSecret": "CnYKcQokAAWBd/OMpxQKZ7Fzm7WnD1vprk6t5a2Cx1OS5ZaTd3Qez6Q9EkkA8xjtHtVE4ZD8CMqa1bWVwiTggI/McQvx7+bvuytA9ztnivj08xOIIJy2zV9aU2w9RykpEXPk7pXZCLT3vMtt+5dho9m8igg6EP4D",
+	"rotationStatus": 1,
+	"secretType": 2,
+	"created": 1689877493455,
+	"updated": 1689877493455
+}
+Decrypting Backup Secret with Tenant's GCP KMS using provided credentials...
+Decrypted Backup Secret:
+          ScbKs2h0XSaBQ/vXp04RmChAffLjh2nxBgRT95j21FM=
+Hashing Over Tenant String:
+          tenant-gcp-derivPath
+Recovered Deterministic Key:
+          +5RA+h4hWWs28cDBaJ0xf6VekSt+NyqJLnj9/GLugMBgwPhV/Qcefs21asNN+iN3h1H8MSjRlgA+V7CyPfmFYw==
+AES-SIV Decrypting Deterministic Data...
+Recovered Data:
+          SmltIEJyaWRnZXI=
+Original Data (String):
+          Jim Bridger
 ```

--- a/examples/disaster-recovery-example/package.json
+++ b/examples/disaster-recovery-example/package.json
@@ -1,18 +1,20 @@
 {
-    "name": "tsc-node-example",
-    "version": "1.0.0",
-    "main": "src/index.js",
-    "license": "MIT",
-    "devDependencies": {
-        "typescript": "^4.3.5"
-    },
-    "dependencies": {
-        "@google-cloud/kms": "^2.6.0",
-        "@types/node": "^16.6.0",
-        "ts-proto": "^1.82.5"
-    },
-    "scripts": {
-        "start": "yarn proto && yarn tsc --target ES6 --sourceMap false --module CommonJS --outDir ./dist/src src/index.ts && node dist/src/index.js",
-        "proto": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src ./transform.proto"
-    }
+  "name": "tsc-node-example",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^4.3.5"
+  },
+  "dependencies": {
+    "@google-cloud/kms": "^2.6.0",
+    "@types/node": "^16.6.0",
+    "miscreant": "^0.3.2",
+    "ts-proto": "^1.82.5"
+  },
+  "scripts": {
+    "start": "yarn proto && yarn tsc --target ES6 --sourceMap false --module CommonJS --outDir ./dist/src src/index.ts && node dist/src/index.js",
+    "deterministic": "yarn proto && yarn tsc --target ES6 --sourceMap false --module CommonJS --outDir ./dist/src src/deterministic.ts && node dist/src/deterministic.js",
+    "proto": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src ./transform.proto"
+  }
 }

--- a/examples/disaster-recovery-example/src/deterministic.ts
+++ b/examples/disaster-recovery-example/src/deterministic.ts
@@ -74,7 +74,7 @@ if (require.main == module) {
         /*
         We can now use the recovered `deterministicKey` to AES-SIV decrypt the deterministic data. This part of the
         process will vary the most language to language as AES-SIV libraries all have slight differences in interface.
-        There is no AES-SIV associated data attached to IronCore deterministic documents.
+        There is no AES-SIV associated data attached to IronCore deterministic values.
         */
         console.log("AES-SIV Decrypting Deterministic Data...");
         const cryptoProvider = new miscreant.PolyfillCryptoProvider();

--- a/examples/disaster-recovery-example/src/deterministic.ts
+++ b/examples/disaster-recovery-example/src/deterministic.ts
@@ -1,0 +1,92 @@
+import * as crypto from "crypto";
+import * as miscreant from "miscreant";
+import {retrieveDek} from "./index";
+
+// Only run through the example if this module was executed (vs imported).
+if (require.main == module) {
+    (async () => {
+        /*
+        These values were taken from the `deterministic-roundtrip` example 1, when run with `tenant-gcp` from the demo deployment.
+        In a real situation these would be the values that you have stored in your database or other persistence layer.
+        */
+        const deterministicEncryptedValue = Buffer.from([
+            0, 0, 19, 247, 0, 0, 120, 82, 176, 74, 41, 28, 85, 84, 151, 164, 104, 252, 207, 111, 251, 109, 137, 3, 164, 75, 158, 246, 69, 37, 83, 19, 163,
+        ]);
+        console.log(`Deterministic Encrypted Value:
+          ${deterministicEncryptedValue.toString("base64")}`);
+        /*
+        The first 6 bytes of the deterministic value are the secret ID. In this case it's 5111.
+        */
+        const secretId = deterministicEncryptedValue.readUInt32BE(0);
+        console.log(`Recovered Secret ID:
+          ${secretId}`);
+
+        /*
+        We took that secretId and pulled out its secret from our manual backup with
+        `cat secret-recovery.json | jq '.result | map(select(.tenantSecretId == secretId))'`.
+        The same thing could be programatically done if you have the secret backup up in a DB or file,
+        or still have access to the Config Broker by way of the Vendor API or UI.
+
+        WARNING: You must back up encrypted secrets periodically to avoid data loss! See current [IronCore documentation](https://docs.ironcorelabs.com)
+                 for information on obtaining backups of encrypted secrets.
+        */
+        const backedUpSecret = {
+            tenantProvidedId: "tenant-gcp",
+            numericId: 5111,
+            id: "4a7f76dd-a0fb-4642-b15b-8423a983cc88",
+            tenantSecretId: 5111,
+            secretFingerprint: "tMoo5p0wpn3J2AS3iJptVWAS19B9zvj1nDGltf40wos=",
+            secretPath: "secretPath",
+            kmsConfigId: 510,
+            migrationStatus: 1,
+            encryptedSecret:
+                "CnYKcQokAAWBd/OMpxQKZ7Fzm7WnD1vprk6t5a2Cx1OS5ZaTd3Qez6Q9EkkA8xjtHtVE4ZD8CMqa1bWVwiTggI/McQvx7+bvuytA9ztnivj08xOIIJy2zV9aU2w9RykpEXPk7pXZCLT3vMtt+5dho9m8igg6EP4D",
+            rotationStatus: 1,
+            secretType: 2,
+            created: 1689877493455,
+            updated: 1689877493455,
+        };
+        console.log(`Retrieved Backup Secret: ${JSON.stringify(backedUpSecret, null, "\t")}`);
+
+        /*
+        To decrypt the secret itself we need to follow the same process we do for other standard encrypted IronCore documents. See
+        `disaster-recovery-example/src/index.ts` for that process. We'll call out to that file from here instead of repeating ourselves.
+        */
+        console.log("Decrypting Backup Secret with Tenant's GCP KMS using provided credentials...");
+        const decryptedSecret = await retrieveDek(backedUpSecret.encryptedSecret);
+        console.log(`Decrypted Backup Secret:
+          ${Buffer.from(decryptedSecret).toString("base64")}`);
+
+        /*
+        Use the decrypted secret as a key in a HMAC-SHA512 hash to get the deterministic key. You can see that you need
+        to know what derivation path you called the TSC with for any given data in your system (which you already do or it's
+        not decryptable).
+        */
+        const derivationString = `${backedUpSecret.tenantProvidedId}-derivPath`;
+        console.log(`Hashing Over Tenant String:
+          ${derivationString}`);
+        const hmac = crypto.createHmac("sha512", decryptedSecret);
+        hmac.update(derivationString);
+        const deterministicKey = hmac.digest();
+        console.log(`Recovered Deterministic Key:
+          ${deterministicKey.toString("base64")}`);
+
+        /*
+        We can now use the recovered `deterministicKey` to AES-SIV decrypt the deterministic data. This part of the
+        process will vary the most language to language as AES-SIV libraries all have slight differences in interface.
+        There is no AES-SIV associated data attached to IronCore deterministic documents.
+        */
+        console.log("AES-SIV Decrypting Deterministic Data...");
+        const cryptoProvider = new miscreant.PolyfillCryptoProvider();
+        const siv = await miscreant.SIV.importKey(deterministicKey, "AES-SIV", cryptoProvider);
+        // slice past the secretId and padding to the ciphertext
+        const recoveredData = Buffer.from(await siv.open(deterministicEncryptedValue.slice(6), []));
+        console.log(`Recovered Data:
+          ${recoveredData.toString("base64")}`);
+        const recoveredString = recoveredData.toString("utf8");
+        console.log(`Original Data (String):
+          ${recoveredString}`);
+    })().catch((e) => {
+        console.log(e);
+    });
+}

--- a/examples/disaster-recovery-example/yarn.lock
+++ b/examples/disaster-recovery-example/yarn.lock
@@ -381,6 +381,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+miscreant@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/miscreant/-/miscreant-0.3.2.tgz#a91c046566cca70bd6b5e9fbdd3f67617fa85034"
+  integrity sha512-fL9KxsQz9BJB2KGPMHFrReioywkiomBiuaLk6EuChijK0BsJsIKJXdVomR+/bPj5mvbFD6wM0CM3bZio9g7OHA==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,8 @@
       let
         lib = import <nixpkgs/lib>;
         pkgs = nixpkgs.legacyPackages.${system};
-      in rec {
+      in
+      rec {
         packages = {
           tenant-security-client-nodejs = {
             name = "tenant-security-client-nodejs";
@@ -29,6 +30,7 @@
             pkgs.nodejs-18_x
             pkgs.protobuf
             (pkgs.yarn.override { nodejs = pkgs.nodejs-18_x; })
+            (pkgs.google-cloud-sdk.withExtraComponents [ pkgs.google-cloud-sdk.components.gke-gcloud-auth-plugin ])
           ];
         };
       });


### PR DESCRIPTION
It uses the standard recovery example to recover its deterministic secret, building on that with the steps required to recover the deterministic data.

See also: https://github.com/IronCoreLabs/website/pull/1114