### PR TITLE
Fix broken module resolution

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -4,12 +4,16 @@ import {ApiErrorResponseSchema} from "./kms/KmsApi";
 import {TenantSecurityErrorCode, TenantSecurityException} from "./TenantSecurityException";
 import {TenantSecurityExceptionUtils} from "./TenantSecurityExceptionUtils";
 import {TspServiceException} from "./TspServiceException";
-import {version} from "../package.json";
 import * as Crypto from "./kms/Crypto";
 import * as DetCrypto from "./kms/DeterministicCrypto";
 import * as http from "http";
 import * as https from "https";
 import * as Joi from "joi";
+
+// Loaded via require so tsc doesn't include package.json in the program and
+// elevate the inferred rootDir above ./src (which would nest the build output).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {version} = require("../package.json") as {version: string};
 
 /**
  * Try to JSON parse error responses from the TSP to extract error codes and messages.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "noUnusedLocals": true,
         "declaration": false,
         "target": "ES6",
+        "rootDir": "./src",
         "module": "commonjs",
         "moduleResolution": "node",
         "resolveJsonModule": true,


### PR DESCRIPTION
When trying to update examples to the latest TSC version I found that all imports failed. This was introduced between 4.0.0 and 4.1.0. When depending on 4.1.0 and later, there would be 2 nested `src` directories so the `package.json` didn't point to the correct files.

The culprit was `import {version} from "../package.json";`. When importing from outside the `src` directory, it implicitly changed the `rootDir` for the project and pushed everything down an extra `src/`. This change both fixes the offending line and also manually sets the `rootDir` so it can't happen again.